### PR TITLE
Add resource type to Checker

### DIFF
--- a/checkers/core.py
+++ b/checkers/core.py
@@ -51,7 +51,7 @@ class Checker:
             return first_param
         except IndexError:
             raise InvalidCheckException(
-                "Checks must include an argument specifying the resource type to check"
+                "Check function specified no arguments. The first argument of a check function must specify the resource type to check"
             )
 
     @property

--- a/checkers/core.py
+++ b/checkers/core.py
@@ -1,6 +1,6 @@
 import inspect
 from typing import Callable, Dict
-from .contracts import CheckResult, CheckResultStatus, Model
+from .contracts import CheckResult, CheckResultStatus, Node
 from .config import Config
 from .exceptions import SkipException, WarnException, InvalidCheckException
 
@@ -38,8 +38,8 @@ class Checker:
         sig = inspect.signature(self.check).parameters
         return sig
 
-    def build_args(self, node: Model):
-        args = {"model": node}
+    def build_args(self, node: Node):
+        args = {node.resource_type: node}
         if "params" in self.signature():
             args.update(params=self.params)
         return args
@@ -64,7 +64,7 @@ class Checker:
     def enabled(self) -> bool:
         return self.params["enabled"] is True
 
-    def run(self, node: Model) -> CheckResult:
+    def run(self, node: Node) -> CheckResult:
         try:
             args = self.build_args(node=node)
             self.check(**args)

--- a/checkers/exceptions.py
+++ b/checkers/exceptions.py
@@ -1,3 +1,9 @@
+class InvalidCheckException(Exception):
+    """
+    Raised when a check function is invalid.
+    """
+
+
 class ConfigException(Exception):
     pass
 

--- a/checkers/runner.py
+++ b/checkers/runner.py
@@ -23,6 +23,8 @@ class Runner:
     def run(self, *paths: List[Path]) -> Iterable[CheckResult]:
         for model in self.model_collector.collect(*paths):
             for check in self.check_collector.collect():
+                if check.resource_type != model.resource_type:
+                    continue
                 res = check.run(model)
                 self.results.append(res)
                 self.printer.print(CheckResultRenderable(res))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,30 @@ def error_check() -> Callable:
     return check
 
 
+@fixture
+def model_check() -> Callable:
+    def check(model):
+        pass
+
+    return check
+
+
+@fixture
+def source_check() -> Callable:
+    def check(source):
+        pass
+
+    return check
+
+
+@fixture
+def undefined_resource_check() -> Callable:
+    def check():
+        pass
+
+    return check
+
+
 @fixture(scope="session")
 def mock_dbt_project(tmpdir_factory):
     root = tmpdir_factory.mktemp("root")


### PR DESCRIPTION
Checks should be able to run against specific types of resources.

For example this check should only run against models.

```py
check(model: Model):
  pass
```

While this check should only run against sources.

```py
check(source: Source):
  pass
```

By associated a resource_type with a check, we allow the Runner to selectively pass the appropriate nodes to be checked.