### PR TITLE
Enable skipping paths for checks via `linter.toml`

### DIFF
--- a/checkers/config.py
+++ b/checkers/config.py
@@ -1,4 +1,5 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
+from pathlib import Path
 import os
 import toml
 from pydantic import BaseModel, ValidationError, ConfigDict
@@ -8,6 +9,8 @@ from .exceptions import ConfigFileNotFoundException, ConfigFileInvalid
 class CheckConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
     enabled: bool = True
+    exclude_paths: Optional[List[Path]] = list()
+    include_paths: Optional[List[Path]] = list()
 
 
 class Config(BaseModel):

--- a/checkers/contracts.py
+++ b/checkers/contracts.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict, List, Any
 import datetime as dt
+from pathlib import Path
 from enum import Enum
 from pydantic import BaseModel, Field
 
@@ -92,7 +93,7 @@ class Node(BaseModel):
     The resource type. Can be `model`, `test`, `seed`, etc.
     """
 
-    original_file_path: str
+    original_file_path: Path
     """
     The path to the file that defined the node, relative to the dbt_project's directory
     """
@@ -185,11 +186,6 @@ class Model(Node):
     columns: Dict[str, Column]
     """
     Dictionary containing details about each column defined in the model's yaml file
-    """
-
-    original_file_path: str
-    """
-    The path to the model
     """
 
     fqn: List[str]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,51 +1,75 @@
 # Configuration
 
-Checkers supports three ways of defining configuration.
+Checkers provides two types of configuration.
 
-1. Through a `linter.toml` file.
-2. Through environment variables.
-3. Through command line arguments.
+The first type is _check parameters_. These are variables that control the behaviour of individual checks. For example, you might want to run a specific check only on certain directories in your dbt project.
 
-The command line arguments take precedence over the environment variables, and the environment variables take precedence over the `linter.toml` file.
+The second type is _runner parameters_. These variables control the behaviour of the runner, and generally apply to every check that gets run. For example, you might want to have all checks only ever raise a warning, rather than fail.
 
-## Creating a `linter.toml` file
-
-To generate a configuration file with the default configuration, use the `checkers init` command.
+Both check parameters and runner parameters can be set via a `linter.toml` configuration file. We recommend generating the `linter.toml` using the `init` command, as it will include all default configuration values for all checks.
 
 ```
 checkers init
 ```
 
-This will generate a file in your current directory called `linter.toml`, and it will contain values similar to the following.
-
-```toml
-dbt_project_dir = "/workspaces/checkers/tests/mock"
-
-[checks.check_model_has_description]
-minimum_description_length = 10
-minimum_description_words = 4
-```
-
-Note that file contains two sections. The first section defines the _configuration options_, which control the behaviour of Checkers. The second section defines _check parameters_, which are used by individual checks. Each of these sections is discussed in more detail below.
-
 ## Check Parameters
 
-Checkers supports passing parameters to individual checks in order to customize their behaviour. These parameters can currently only be defined via the `linter.toml` file.
-
-Here's an example parameter configuration for the check `check_model_has_description`.
+The parameters of an individual check are located in a specific section of the configuration file. Here's what that looks like for two checks `check_model_has_description` and `check_model_has_primary_key_test`.
 
 ```toml
 [checks.check_model_has_description]
+enabled = true
+exclude_paths = []
+include_paths = []
 minimum_description_length = 10
 minimum_description_words = 4
+
+[checks.check_model_has_primary_key_test]
+enabled = true
+exclude_paths = []
+include_paths = []
 ```
 
-For more information about the parameters available for the builtin checks, see the documentation for that specific check. For example, here's the documentation for the [`check_model_has_description`](checks/check_model_has_description.md).
+Notice that some configuration options appear for both checks, such as the `exclude_paths` field. Other options are unique to a specific check, such as `minimum_description_word_length`, which is only relevant for the model description checks.
 
-## Configuration Options
+In the rest of this section we'll describe the check parameters that are common to all checks. For more information about the parameters available for individual checks, you can consult the documentation for that specific check. For example, here's [the documentation for the `check_model_has_description`](checks/check_model_has_description.md).
+
+### `enabled`
+
+This flag can be used to completely disable the check. Disabled checks are never ran.
+
+### `exclude_paths`
+
+A set of paths that the check should skip. The paths must be relative to the dbt project directory.
+
+!!! Info
+    Currently Checkers does not support regexes here.
+
+### `include_paths`
+
+A set of paths that the check should target, so that any node which lives _outside_ of these paths will be skipped. The paths must be relative to the dbt project directory.
+
+!!! Info
+    If a path is defined in both include and exclude paths, then the model will be skipped. Ie, `exclude_paths` takes priority over `include_paths`.
+
+!!! Info
+    Currently Checkers does not support regexes here.
+
+## Runner parameters
+
+The runner can be configured in three ways:
+
+- The `linter.toml` file
+- Command line options specified when using the `checkers` cli.
+- Environment variables
+
+Command line options take precedence over environment variables, and environment variables take precedence over values in the `linter.toml` file.
+
+The runner current supports the following parameters.
 
 ### dbt_project_dir
 
+- `checkers --dbt-project-dir ./path/to/project [COMMAND]`
 - Environment variable: `DBT_PROJECT_DIR`.
 
 The path to a dbt project containing the models to lint.

--- a/docs/custom_checks.md
+++ b/docs/custom_checks.md
@@ -105,20 +105,3 @@ def check_model_has_owner(model: Model):
         skip()
     assert 'owner' in model.meta, "Model must specify an `owner` field in its `meta` block"
 ```
-
-## Warning on models
-
-Another similar use case is to only warn users about issues with some models, while failing on others.
-
-Checkers supports this through providing a special `warn` function.
-
-```py
-from checkers import warn, Model
-
-def check_model_has_owner(model: Model):
-    if model.original_file_path.startswith('finance/'):
-        warn()
-    assert 'owner' in model.meta, "Model must specify an `owner` field in its `meta` block"
-```
-
-Providing a warning can be useful because it alerts your users about an issue without blocking CI. This can be handy when introducing new custom checks where you'd like to validate the check behaves as expected, without potentially blocking your CI.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock
 from pytest import raises
+from pathlib import Path
 from checkers.core import Checker, skip, warn
-from checkers.contracts import CheckResultStatus
+from checkers.contracts import CheckResultStatus, Model
 from checkers.config import Config, CheckConfig
 from checkers.exceptions import SkipException, WarnException, InvalidCheckException
 
@@ -124,6 +126,23 @@ def test_checker_run_with_custom_params(config: Config, model):
     assert res.status == CheckResultStatus.passing
 
 
+def test_checker_run_uses_skip(passing_check, model: Model, config: Config):
+    checker = Checker(check=passing_check, config=config)
+    checker.skip = MagicMock()
+    res = checker.run(model)
+    checker.skip.assert_called_once()
+    assert res.status == CheckResultStatus.passing
+
+
+def test_checker_run_handles_skip(passing_check, model: Model, config: Config):
+    checker = Checker(check=passing_check, config=config)
+    checker.skip = MagicMock()
+    checker.skip.side_effect = SkipException
+    res = checker.run(model)
+    checker.skip.assert_called_once()
+    assert res.status == CheckResultStatus.skipped
+
+
 def test_checker_identifies_resource_type(
     config, model_check, source_check, undefined_resource_check
 ):
@@ -145,3 +164,33 @@ def test_checker_build_check_config(config):
     checker = Checker(check=check_mymodel, config=config)
     check_config = checker.build_check_config()
     assert check_config.enabled == True
+
+
+def test_checker_skip(model: Model, config):
+    def check_tmp(model):
+        pass
+
+    m = model.model_copy(
+        update=dict(original_file_path=Path("models/testing/model.sql"))
+    )
+    checker = Checker(check=check_tmp, config=config)
+    conf = checker.check_config
+
+    # Expect no exception here
+    checker.skip(m)
+
+    # Add an include paths which should cause a skip exception
+    checker.check_config = conf.model_copy(
+        update={"include_paths": [Path("models/dne")]}
+    )
+    with raises(SkipException) as err:
+        checker.skip(m)
+        assert "did not match any included paths" in err
+
+    # Remove the include paths but an an exclude paths, which should also have a skip exception
+    checker.check_config = conf.model_copy(
+        update={"include_paths": [], "exclude_paths": [Path("models/testing")]}
+    )
+    with raises(SkipException) as err:
+        checker.skip(m)
+        assert "excluding path models/testing" in err

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,7 +57,6 @@ def test_checker_with_default_params(config):
 
     checker = Checker(config=config, check=check_something)
     assert checker.params["enabled"] is True
-    assert len(checker.params) == 1
 
 
 def test_checker_with_base_params(config):
@@ -69,7 +68,6 @@ def test_checker_with_base_params(config):
     checker = Checker(config=config, check=check_something)
     assert checker.params["p1"] is 1
     assert checker.params["enabled"] is False
-    assert len(checker.params) == 2
 
 
 def test_checker_with_override_params(config: Config):
@@ -84,7 +82,6 @@ def test_checker_with_override_params(config: Config):
     assert checker.params["enabled"] is True
     assert checker.params["p1"] is 2
     assert checker.params["p2"] is 3
-    assert len(checker.params) == 3
 
 
 def test_checker_build_args_with_default_args(config: Config, model):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from checkers.config import Config
 
 
@@ -9,3 +10,7 @@ def test_mock_project_setup(mock_dbt_project):
 
 def test_config_setup(config: Config):
     assert os.path.exists(config.manifest_path)
+
+
+def test_model_path_instance(model):
+    assert isinstance(model.original_file_path, Path)


### PR DESCRIPTION
Resolves #17 